### PR TITLE
Add catalog-info.yaml for Portal DX integration.

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,7 +5,8 @@ metadata:
   annotations:
     github.com/project-slug: madeiramadeirabr/action-lifecycledoc
   tags:
-    - python
+    - go
+    - libary
 spec:
   type: service
   lifecycle: production

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: action-lifecycledoc
+  annotations:
+    github.com/project-slug: madeiramadeirabr/action-lifecycledoc
+  tags:
+    - python
+spec:
+  type: service
+  lifecycle: production
+  owner: squad-partner-tools-admin
+  

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,5 +10,5 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: squad-partner-tools-admin
+  owner: squad-partner-tools
   

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,7 +6,7 @@ metadata:
     github.com/project-slug: madeiramadeirabr/action-lifecycledoc
   tags:
     - go
-    - libary
+    - github-action
 spec:
   type: service
   lifecycle: production


### PR DESCRIPTION
Esta solicitação pull adiciona um **arquivo de metadados de entidade Backstage** a este repositório para que o componente possa ser adicionado ao catálogo de software da MadeiraMadeira no Portal DX.

Depois que essa solicitação pull for mesclada, o componente ficará disponível.

Sinta-se à vontade para fazer alterações no arquivo. Para mais informações, leia a documentação com as orientações específicas em [Arquivo de Configuração](https://madeiramadeira.atlassian.net/wiki/spaces/DX/pages/2744844533/Arquivo+de+Configura+o) no Confluence do DX Team.